### PR TITLE
fix: license 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,4 +311,4 @@
 
 ## 协议
 
-[CC-BY 4.0](LICENSE)
+[CC-BY 4.0](https://github.com/Vonng/ddia/blob/master/LICENSE)


### PR DESCRIPTION
docsify 似乎不支持非 md 文件，导致 <https://vonng.github.io/ddia/#/LICENSE> 会出现 404.

也可以考虑写成 `[CC-BY 4.0](https://raw.githubusercontent.com/Vonng/ddia/master/LICENSE)`

Signed-off-by: 117503445 <t117503445@gmail.com>