### PR TITLE
 Feature: Convert Markdown to EPUB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 .DS_Store
 tmp/
+output/

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,7 @@ doc:
 translate:
 	bin/zh-tw.py
 
+epub:
+	bin/epub
+
 .PHONY: default doc translate

--- a/bin/epub
+++ b/bin/epub
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -ex
-
 # Set the directory containing Markdown files
 SCRIPT_DIR=$(dirname "$0")
 INPUT_DIR=$(cd "$(dirname "$SCRIPT_DIR")" && pwd)
@@ -19,7 +17,7 @@ convert_to_epub() {
 	local meta_file=${INPUT_DIR}/metadata.yaml
 	local css_file=${INPUT_DIR}/js/epub.css
 
-	pandoc -o "$OUTPUT_BOOK" "$meta_file" \
+	pandoc -o "$OUTPUT_BOOK" --metadata-file="$meta_file" \
 		--toc-depth=2 \
 		--top-level-division=chapter \
 		--file-scope=true \

--- a/bin/epub
+++ b/bin/epub
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Set the directory containing Markdown files
+SCRIPT_DIR=$(dirname "$0")
+INPUT_DIR=$(cd "$(dirname "$SCRIPT_DIR")" && pwd)
+OUTPUT_DIR="$INPUT_DIR/output"
+
+# Create output directory if it doesn't exist
+mkdir -p "$OUTPUT_DIR"
+
+convert_to_epub() {
+	# convert all EPUB files into a single EPUB book
+	OUTPUT_BOOK="$OUTPUT_DIR/ddia.epub"
+	rm -f "$OUTPUT_BOOK"
+	echo "Converting all EPUB files into $OUTPUT_BOOK..."
+
+	local meta_file=${INPUT_DIR}/metadata.yaml
+	local css_file=${INPUT_DIR}/js/epub.css
+
+	pandoc -o "$OUTPUT_BOOK" "$meta_file" \
+		--toc-depth=2 \
+		--top-level-division=chapter \
+		--file-scope=true \
+		--css="$css_file" \
+		--webtex \
+		--wrap=preserve \
+		"${INPUT_DIR}"/SUMMARY.md \
+		"${INPUT_DIR}"/README.md \
+		"${INPUT_DIR}"/preface.md \
+		"${INPUT_DIR}"/part-i.md \
+		"${INPUT_DIR}"/ch1.md \
+		"${INPUT_DIR}"/ch2.md \
+		"${INPUT_DIR}"/ch3.md \
+		"${INPUT_DIR}"/ch4.md \
+		"${INPUT_DIR}"/part-ii.md \
+		"${INPUT_DIR}"/ch5.md \
+		"${INPUT_DIR}"/ch6.md \
+		"${INPUT_DIR}"/ch7.md \
+		"${INPUT_DIR}"/ch8.md \
+		"${INPUT_DIR}"/ch9.md \
+		"${INPUT_DIR}"/part-iii.md \
+		"${INPUT_DIR}"/ch10.md \
+		"${INPUT_DIR}"/ch11.md \
+		"${INPUT_DIR}"/ch12.md \
+		"${INPUT_DIR}"/colophon.md \
+		"${INPUT_DIR}"/glossary.md
+
+	echo "Converted EPUB book created at $OUTPUT_BOOK."
+}
+
+convert_to_epub

--- a/js/epub.css
+++ b/js/epub.css
@@ -1,0 +1,221 @@
+/* This defines styles and classes used in the book */
+@page {
+  margin: 10px;
+}
+html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p,
+blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img,
+ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center,
+fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, figure, figcaption, footer, header,
+hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video, ol,
+ul, li, dl, dt, dd {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  vertical-align: baseline;
+}
+html {
+  line-height: 1.2;
+  font-family: Georgia, serif;
+  color: #1a1a1a;
+}
+p {
+  text-indent: 0;
+  margin: 1em 0;
+  widows: 2;
+  orphans: 2;
+}
+a, a:visited {
+  color: #1a1a1a;
+}
+img {
+  max-width: 100%;
+}
+sup {
+  vertical-align: super;
+  font-size: smaller;
+}
+sub {
+  vertical-align: sub;
+  font-size: smaller;
+}
+h1 {
+  margin: 3em 0 0 0;
+  font-size: 2em;
+  page-break-before: always;
+  line-height: 150%;
+}
+h2 {
+  margin: 1.5em 0 0 0;
+  font-size: 1.5em;
+  line-height: 135%;
+}
+h3 {
+  margin: 1.3em 0 0 0;
+  font-size: 1.3em;
+}
+h4 {
+  margin: 1.2em 0 0 0;
+  font-size: 1.2em;
+}
+h5 {
+  margin: 1.1em 0 0 0;
+  font-size: 1.1em;
+}
+h6 {
+  font-size: 1em;
+}
+h1, h2, h3, h4, h5, h6 {
+  text-indent: 0;
+  text-align: left;
+  font-weight: bold;
+  page-break-after: avoid;
+  page-break-inside: avoid;
+}
+
+ol, ul {
+  margin: 1em 0 0 1.7em;
+}
+li > ol, li > ul {
+  margin-top: 0;
+}
+blockquote {
+  margin: 1em 0 1em 1.7em;
+}
+code {
+  font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
+  font-size: 85%;
+  margin: 0;
+  hyphens: manual;
+}
+/*pre {*/
+/*  margin: 1em 0;*/
+/*  overflow: auto;*/
+/*}*/
+pre code {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  background-color: #f5f5f5;
+  padding: 1em;
+}
+.sourceCode {
+  background-color: transparent;
+  overflow: visible;
+}
+hr {
+  background-color: #1a1a1a;
+  border: none;
+  height: 1px;
+  margin: 1em 0;
+}
+table {
+  margin: 1em 0;
+  border-collapse: collapse;
+  width: 100%;
+  overflow-x: auto;
+  display: block;
+}
+table caption {
+  margin-bottom: 0.75em;
+}
+tbody {
+  margin-top: 0.5em;
+  border-top: 1px solid #1a1a1a;
+  border-bottom: 1px solid #1a1a1a;
+}
+th, td {
+  padding: 0.25em 0.5em 0.25em 0.5em;
+}
+th {
+  border-top: 1px solid #1a1a1a;
+}
+header {
+  margin-bottom: 4em;
+  text-align: center;
+}
+#TOC li {
+  list-style: none;
+}
+#TOC ul {
+  padding-left: 1.3em;
+}
+#TOC > ul {
+  padding-left: 0;
+}
+#TOC a:not(:hover) {
+  text-decoration: none;
+}
+code {
+  white-space: pre-wrap;
+}
+span.smallcaps {
+  font-variant: small-caps;
+}
+
+/* This is the most compatible CSS, but it only allows two columns: */
+div.column {
+  display: inline-block;
+  vertical-align: top;
+  width: 50%;
+}
+/* If you can rely on CSS3 support, use this instead: */
+/* div.columns {
+  display: flex;
+  gap: min(4vw, 1.5em);
+}
+div.column {
+  flex: auto;
+  overflow-x: auto;
+} */
+
+div.hanging-indent {
+  margin-left: 1.5em;
+  text-indent: -1.5em;
+}
+ul.task-list {
+  list-style: none;
+}
+ul.task-list li input[type="checkbox"] {
+  width: 0.8em;
+  margin: 0 0.8em 0.2em -1.6em;
+  vertical-align: middle;
+}
+.display.math {
+  display: block;
+  text-align: center;
+  margin: 0.5rem auto;
+}
+
+/* For title, author, and date on the cover page */
+h1.title { }
+p.author { }
+p.date { }
+
+nav#toc ol, nav#landmarks ol {
+  padding: 0;
+  margin-left: 1em;
+}
+nav#toc ol li, nav#landmarks ol li {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+a.footnote-ref {
+  vertical-align: super;
+}
+em, em em em, em em em em em {
+  font-style: italic;
+}
+em em, em em em em {
+  font-style: normal;
+}
+q {
+  quotes: "“" "”" "‘" "’";
+}
+@media screen { /* Workaround for iBooks issue; see #6242 */
+  .sourceCode {
+    overflow: visible !important;
+    white-space: pre-wrap !important;
+  }
+}

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,5 @@
+---
+title: 设计数据密集型应用
+author: Martin Kleppmann
+rights:  Creative Commons Non-Commercial Share Alike 3.0
+language: 中文

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,13 @@
----
-title: 设计数据密集型应用
-author: Martin Kleppmann
+title:
+  - type: main
+    text: 设计数据密集型应用
+  - type: subtitle
+    text: 可靠、可扩展、可维护的系统
+
+creator:
+  - role: author
+    name: Martin Kleppmann
+
 rights:  Creative Commons Non-Commercial Share Alike 3.0
 language: 中文
+cover-image: ./img/title.png


### PR DESCRIPTION
This PR adds support for converting Markdown files into EPUB format, making it easier to read notes in apps like Apple Books and WeChat Read.

Highlights:

Added EPUB export functionality
Compatible with multiple ebook platforms
Looking forward to your review! 