### PR TITLE
Fix bracket escaping in GDPR quote rendered as LaTeX math

### DIFF
--- a/content/tw/ch14.md
+++ b/content/tw/ch14.md
@@ -102,7 +102,7 @@ breadcrumbs: false
 
 此外，資料從使用者身上被抽取是單向過程，不是具有真實互惠的關係，也不是公平的價值交換。這裡沒有對話，沒有讓使用者協商“提供多少資料、換取什麼服務”的空間：服務與使用者之間的關係高度不對稱、單向度。規則由服務制定，而非使用者 [^30], [^31]。
 
-在歐盟，《通用資料保護條例》（GDPR）要求同意必須是 “freely given, specific, informed, and unambiguous”，並且使用者必須能夠 “refuse or withdraw consent without detriment”——否則不被視為 “freely given”。任何徵求同意的請求都必須以 “an intelligible and easily accessible form, using clear and plain language” 撰寫。此外，“silence, pre-ticked boxes or inactivity \[do not\] constitute consent” [^32]。除同意外，個人資料處理還可基於其他合法基礎，例如 *legitimate interest*，它允許某些資料用途，如防欺詐 [^33]。
+在歐盟，《通用資料保護條例》（GDPR）要求同意必須是 “freely given, specific, informed, and unambiguous”，並且使用者必須能夠 “refuse or withdraw consent without detriment”——否則不被視為 “freely given”。任何徵求同意的請求都必須以 “an intelligible and easily accessible form, using clear and plain language” 撰寫。此外，"silence, pre-ticked boxes or inactivity &#91;do not&#93; constitute consent" [^32]。除同意外，個人資料處理還可基於其他合法基礎，例如 *legitimate interest*，它允許某些資料用途，如防欺詐 [^33]。
 
 你可能會說，不同意被監視的使用者可以選擇不用這項服務。但這種選擇同樣不自由：如果某項服務流行到“被大多數人視為基本社會參與所必需” [^30]，那就不能合理期待人們退出——使用它在事實上成了強制（*de facto* mandatory）。例如，在多數西方社群中，攜帶智慧手機、透過社交網路社交、使用 Google 獲取資訊，已經成為常態。尤其當服務具有網路效應時，選擇 *不* 使用它會付出社會成本。
 


### PR DESCRIPTION
## Problem

In the GDPR section, the quote:

> "silence, pre-ticked boxes or inactivity \[do not\] constitute consent"

uses `\[do not\]` to escape the brackets. However, `\[ ... \]` is the
display-math delimiter for MathJax/KaTeX, so the phrase gets rendered as a
centered math expression (`donot`, with spaces collapsed) instead of plain
text.

## Fix

Replaced `\[do not\]` with HTML entities `&#91;do not&#93;`, which render
as literal `[do not]` in all environments (with or without math support
enabled) and won't be parsed as a reference link either.

## Before / After

- Before: renders as centered italic `donot`
- After: renders inline as `[do not]`